### PR TITLE
🚀 Fix: Data Export & Refined Changelog Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ display_errors = Off
 - **Fix export données** : les requêtes API sont désormais séquentielles (le `Promise.all` causait des blocages de session PHP côté serveur, résultant en un export vide)
 - **Import complet** : l'import restaure maintenant tous les champs thème (`theme_mode`, couleurs, gradient…) et `overtime_period`, avec rétrocompatibilité des anciens fichiers v1.0
 - Renommage des fichiers exportés : `primetime-*` → `timetrack-*`
+- La popup changelog ne s'affiche plus pour les versions patch (ex. 1.6 → 1.6.1), uniquement pour les changements majeurs/mineurs
 
 ### v1.6 — 8 avril 2026
 - **Thèmes personnalisables** : sélecteur 3 positions Clair / Sombre / Custom dans les paramètres, animation à l'activation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Application de suivi du temps de travail en self-hosted, construite avec React + TypeScript (frontend) et PHP + MySQL (backend).
 
-![Version](https://img.shields.io/badge/version-1.6-blue)
+![Version](https://img.shields.io/badge/version-1.6.1-blue)
 ![Stack](https://img.shields.io/badge/stack-React%20%2B%20PHP%20%2B%20MySQL-green)
 
 ---
@@ -214,6 +214,11 @@ display_errors = Off
 ---
 
 ## Changelog
+
+### v1.6.1 — 10 avril 2026
+- **Fix export données** : les requêtes API sont désormais séquentielles (le `Promise.all` causait des blocages de session PHP côté serveur, résultant en un export vide)
+- **Import complet** : l'import restaure maintenant tous les champs thème (`theme_mode`, couleurs, gradient…) et `overtime_period`, avec rétrocompatibilité des anciens fichiers v1.0
+- Renommage des fichiers exportés : `primetime-*` → `timetrack-*`
 
 ### v1.6 — 8 avril 2026
 - **Thèmes personnalisables** : sélecteur 3 positions Clair / Sombre / Custom dans les paramètres, animation à l'activation

--- a/api/migrate.php
+++ b/api/migrate.php
@@ -5,7 +5,7 @@
  * USAGE (à exécuter depuis le navigateur ou curl sur le serveur Plesk) :
  *   GET  /api/migrate.php?token=VOTRE_TOKEN_SECRET
  *
- * Ce script lit le fichier data_migration/primetime-export-*.json
+ * Ce script lit le fichier data_migration/timetrack-export-*.json
  * et insère les données dans les tables users, user_preferences et work_sessions.
  *
  * ⚠️  SUPPRIMEZ ou DÉSACTIVEZ ce fichier après utilisation !
@@ -26,10 +26,10 @@ header('Content-Type: text/plain; charset=utf-8');
 
 // ── Trouver le fichier JSON ──────────────────────────────────────────────────
 $dataDir = __DIR__ . '/../data_migration';
-$files   = glob("$dataDir/primetime-export-*.json");
+$files   = glob("$dataDir/timetrack-export-*.json");
 
 if (empty($files)) {
-    exit("Aucun fichier primetime-export-*.json trouvé dans data_migration/");
+    exit("Aucun fichier timetrack-export-*.json trouvé dans data_migration/");
 }
 
 // Prendre le plus récent

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -205,7 +205,7 @@ export function Settings({ onClose, initialPreferences }: SettingsProps) {
     try {
       const data = await exportUserData(user.id);
       const date = new Date().toISOString().split('T')[0];
-      downloadJSON(data, `primetime-export-${date}.json`);
+      downloadJSON(data, `timetrack-export-${date}.json`);
       setMessage('Export JSON téléchargé avec succès');
     } catch {
       setError("Erreur lors de l'export");
@@ -220,7 +220,7 @@ export function Settings({ onClose, initialPreferences }: SettingsProps) {
     try {
       const data = await exportUserData(user.id);
       const date = new Date().toISOString().split('T')[0];
-      downloadCSV(data.work_sessions, `primetime-sessions-${date}.csv`);
+      downloadCSV(data.work_sessions, `timetrack-sessions-${date}.csv`);
       setMessage('Export CSV téléchargé avec succès');
     } catch {
       setError("Erreur lors de l'export");

--- a/src/components/TimeTracker.tsx
+++ b/src/components/TimeTracker.tsx
@@ -7,7 +7,7 @@ import { Statistics } from './Statistics';
 import { EditHistory } from './EditHistory';
 import { ConfirmModal } from './ConfirmModal';
 import { ChangelogModal } from './ChangelogModal';
-import { APP_VERSION } from '../lib/changelog';
+import { APP_VERSION, majorMinor } from '../lib/changelog';
 
 export function TimeTracker() {
   const { user, logout } = useAuth();
@@ -113,7 +113,7 @@ export function TimeTracker() {
 
     if (data) {
       setPreferences(data);
-      if (data.last_seen_version !== APP_VERSION) {
+      if (majorMinor(data.last_seen_version ?? '') !== majorMinor(APP_VERSION)) {
         setShowChangelog(true);
       }
     }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,4 +1,10 @@
-export const APP_VERSION = '1.6';
+export const APP_VERSION = '1.6.1';
+
+/** Extrait la version majeure.mineure (ex: '1.6.1' → '1.6') */
+export function majorMinor(version: string): string {
+  const parts = version.split('.');
+  return parts.length >= 2 ? `${parts[0]}.${parts[1]}` : version;
+}
 
 export interface ChangelogEntry {
   version: string;

--- a/src/lib/dataTransfer.ts
+++ b/src/lib/dataTransfer.ts
@@ -13,14 +13,18 @@ export interface ExportData {
 }
 
 export async function exportUserData(userId: string): Promise<ExportData> {
-  const [userResult, prefsResult, sessionsResult] = await Promise.all([
-    supabase.from<Pick<User, 'id' | 'username' | 'created_at'>>('users').select('id, username, created_at').eq('id', userId).maybeSingle(),
-    supabase.from<UserPreferences>('user_preferences').select('*').eq('user_id', userId).maybeSingle(),
-    supabase.from<WorkSession[]>('work_sessions').select('*').eq('user_id', userId).order('date', { ascending: true }).order('clock_in', { ascending: true }),
-  ]);
+  // Requêtes séquentielles : PHP verrouille le fichier session (session_start),
+  // les appels parallèles se bloquent mutuellement sur le serveur Plesk.
+  const userResult = await supabase.from<Pick<User, 'id' | 'username' | 'created_at'>>('users').select('id, username, created_at').eq('id', userId).maybeSingle();
+  const prefsResult = await supabase.from<UserPreferences>('user_preferences').select('*').eq('user_id', userId).maybeSingle();
+  const sessionsResult = await supabase.from<WorkSession[]>('work_sessions').select('*').eq('user_id', userId).order('date', { ascending: true }).order('clock_in', { ascending: true });
+
+  if (userResult.error) console.error('[export] Erreur users:', userResult.error);
+  if (prefsResult.error) console.error('[export] Erreur preferences:', prefsResult.error);
+  if (sessionsResult.error) console.error('[export] Erreur sessions:', sessionsResult.error);
 
   return {
-    version: '1.0',
+    version: '1.1',
     exported_at: new Date().toISOString(),
     user: userResult.data ?? { id: userId, username: '', created_at: '' },
     preferences: prefsResult.data,
@@ -83,19 +87,34 @@ export async function importUserData(userId: string, data: ExportData): Promise<
   }
 
   if (data.preferences) {
+    const prefs = data.preferences;
+    const updateData: Record<string, unknown> = {
+      dark_mode: prefs.dark_mode,
+      required_work_hours: prefs.required_work_hours,
+      required_lunch_break_minutes: prefs.required_lunch_break_minutes,
+      end_of_day_threshold: prefs.end_of_day_threshold,
+      notifications_enabled: prefs.notifications_enabled,
+      weekly_overtime_minutes: prefs.weekly_overtime_minutes,
+      use_overtime_compensation: prefs.use_overtime_compensation,
+      minimum_end_time: prefs.minimum_end_time,
+      use_minimum_end_time: prefs.use_minimum_end_time,
+    };
+
+    // Champs ajoutés en 1.5+ / 1.6+ (absents des anciens exports)
+    if (prefs.overtime_period !== undefined) updateData.overtime_period = prefs.overtime_period;
+    if (prefs.theme_mode !== undefined) updateData.theme_mode = prefs.theme_mode;
+    if (prefs.theme_primary !== undefined) updateData.theme_primary = prefs.theme_primary;
+    if (prefs.theme_secondary !== undefined) updateData.theme_secondary = prefs.theme_secondary;
+    if (prefs.theme_accent !== undefined) updateData.theme_accent = prefs.theme_accent;
+    if (prefs.theme_use_gradient !== undefined) updateData.theme_use_gradient = prefs.theme_use_gradient;
+    if (prefs.theme_app_bg !== undefined) updateData.theme_app_bg = prefs.theme_app_bg;
+    if (prefs.theme_surface_bg !== undefined) updateData.theme_surface_bg = prefs.theme_surface_bg;
+    if (prefs.theme_text_color !== undefined) updateData.theme_text_color = prefs.theme_text_color;
+    if (prefs.theme_highlight_bg !== undefined) updateData.theme_highlight_bg = prefs.theme_highlight_bg;
+
     const { error } = await supabase
       .from('user_preferences')
-      .update({
-        dark_mode: data.preferences.dark_mode,
-        required_work_hours: data.preferences.required_work_hours,
-        required_lunch_break_minutes: data.preferences.required_lunch_break_minutes,
-        end_of_day_threshold: data.preferences.end_of_day_threshold,
-        notifications_enabled: data.preferences.notifications_enabled,
-        weekly_overtime_minutes: data.preferences.weekly_overtime_minutes,
-        use_overtime_compensation: data.preferences.use_overtime_compensation,
-        minimum_end_time: data.preferences.minimum_end_time,
-        use_minimum_end_time: data.preferences.use_minimum_end_time,
-      })
+      .update(updateData)
       .eq('user_id', userId);
 
     if (!error) {


### PR DESCRIPTION
### 📝 Description
Cette PR corrige un problème critique sur l'export de données, améliore la robustesse de l'import et affine l'expérience utilisateur concernant les notifications de mise à jour.

### 🛠 Changements principaux

#### 1. Export & Import de données
* **Correction du blocage de session :** L'export renvoyait un JSON vide à cause d'un verrouillage de fichier (session PHP) lors d'appels API concurrents. Le processus est passé en **requêtes séquentielles**.
* **Support des thèmes :** L'import restaure désormais les préférences de thème et d'heures supplémentaires, avec une gestion de la rétrocompatibilité.
* **Renommage des fichiers :** Les exports utilisent désormais le préfixe `timetrack-*` au lieu de `primetime-*` pour plus de cohérence.

#### 2. Expérience Utilisateur (UX)
* **Logique du Changelog :** La popup de changelog ne s'affiche désormais que pour les changements de versions majeures ou mineures. Les versions de patch (ex: `1.6.0` → `1.6.1`) sont désormais silencieuses.
* **Version :** Bump de l'application en **v1.6.1**.

### 🧪 Comment tester ?
1.  **Export :** Lancer un export et vérifier que le fichier JSON contient bien toutes les données (plus de fichier vide).
2.  **Import :** Importer un ancien fichier et vérifier que les préférences de thème sont bien appliquées.
3.  **Changelog :** Passer de la v1.6.0 à la v1.6.1 et vérifier que la popup de changelog **ne s'affiche pas**.

---
> **Note :** Travail réalisé en collaboration avec Claude Opus 4.6.