### PR TITLE
feat: horaires de travail variables par jour de la semaine (v1.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Application de suivi du temps de travail en self-hosted, construite avec React + TypeScript (frontend) et PHP + MySQL (backend).
 
-![Version](https://img.shields.io/badge/version-1.6.2-blue)
+![Version](https://img.shields.io/badge/version-1.7.0-blue)
 ![Stack](https://img.shields.io/badge/stack-React%20%2B%20PHP%20%2B%20MySQL-green)
 
 ---
@@ -214,6 +214,12 @@ display_errors = Off
 ---
 
 ## Changelog
+
+### v1.7.0 — 1 juin 2026
+- **Horaires variables par jour de la semaine** : nouvelle option « Horaire personnalisé par jour » dans les paramètres, pensée pour les temps partiels — définissez un nombre d'heures différent pour chaque jour (Lun→Dim), `0` pour un jour non travaillé
+- Tous les calculs s'adaptent à l'horaire du jour : objectif quotidien, heure de fin estimée, progression, pause déjeuner adaptative, heures supplémentaires sur la période et statistiques
+- Comportement inchangé par défaut : sans activation de l'option, une seule valeur d'heures s'applique à tous les jours
+- Base de données : nouvelles colonnes `use_custom_schedule` et `work_hours_by_day` (migration `db/migrations/migration_1.7.sql`)
 
 ### v1.6.2 — 21 avril 2026
 - **Fix compensation heures supp** : la pause déjeuner adaptative ne gonfle plus pour annuler le crédit d'heures supp quand une heure de départ minimum est définie

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Application de suivi du temps de travail en self-hosted, construite avec React +
 - Modification du nom d'utilisateur et du mot de passe
 - **Thèmes** : sélecteur Clair / Sombre / Custom, 12 presets (OLED, Cosy, Dracula, Nord, Solarized…) et personnalisation complète des couleurs (primaire, secondaire, accent, fond de page, fond des cartes, mises en avant, police auto/claire/foncée), persistés en base par utilisateur
 - Configuration : heures de travail requises, durée de pause déjeuner, seuil de départ (%)
+- **Horaires variables par jour** : option « Horaire personnalisé par jour » pour les temps partiels — un nombre d'heures différent pour chaque jour (Lun→Dim, `0` = jour non travaillé). Tous les calculs s'adaptent au jour de la semaine
 - Gestion des heures supplémentaires (compensation, période de calcul configurable)
 - Export des données (JSON / CSV) et import
 - Suppression complète du compte (cascade sur toutes les données)
@@ -84,7 +85,7 @@ TIMETRACK/
 | `work_sessions` | Sessions de travail (clock_in, clock_out, pause) |
 
 Le schéma complet pour une **installation fraîche** est dans [db/schema.sql](db/schema.sql).
-Les **mises à jour** d'une base existante se font via les scripts versionnés dans [db/migrations/](db/migrations/) (ex. `migration_1.6.sql` pour passer en 1.6).
+Les **mises à jour** d'une base existante se font via les scripts versionnés dans [db/migrations/](db/migrations/) (ex. `migration_1.7.sql` pour passer en 1.7 — ajoute les colonnes `use_custom_schedule` et `work_hours_by_day`).
 
 ---
 

--- a/api/helpers.php
+++ b/api/helpers.php
@@ -149,10 +149,17 @@ function cast_prefs(array $row): array
     $bools = [
         'dark_mode', 'notifications_enabled',
         'use_overtime_compensation', 'use_minimum_end_time',
-        'theme_use_gradient',
+        'theme_use_gradient', 'use_custom_schedule',
     ];
     foreach ($bools as $f) {
         $row[$f] = (bool)(int)($row[$f] ?? 0);
+    }
+    // Horaires par jour (1.7) : stocke en JSON, expose un tableau (ou null).
+    if (isset($row['work_hours_by_day']) && $row['work_hours_by_day'] !== null) {
+        $decoded = json_decode($row['work_hours_by_day'], true);
+        $row['work_hours_by_day'] = is_array($decoded) ? $decoded : null;
+    } else {
+        $row['work_hours_by_day'] = null;
     }
     $row['theme_mode']       = $row['theme_mode']       ?? 'light';
     $row['theme_primary']    = $row['theme_primary']    ?? '#3b82f6';

--- a/api/preferences.php
+++ b/api/preferences.php
@@ -87,19 +87,32 @@ switch ($action) {
             }
         }
 
+        // Horaires par jour (1.7) : tableau de 7 nombres >= 0, ou null.
+        if (isset($data['work_hours_by_day']) && $data['work_hours_by_day'] !== null) {
+            $sched = $data['work_hours_by_day'];
+            if (!is_array($sched) || count($sched) !== 7) {
+                json_error('work_hours_by_day doit comporter 7 valeurs', 400);
+            }
+            foreach ($sched as $h) {
+                if (!is_numeric($h) || $h < 0) {
+                    json_error('Valeur work_hours_by_day invalide', 400);
+                }
+            }
+        }
+
         $allowed = [
             'dark_mode', 'notifications_enabled', 'required_work_hours',
             'required_lunch_break_minutes', 'end_of_day_threshold',
             'weekly_overtime_minutes', 'use_overtime_compensation',
             'minimum_end_time', 'use_minimum_end_time', 'last_seen_version',
-            'overtime_period',
+            'overtime_period', 'use_custom_schedule', 'work_hours_by_day',
             'theme_mode', 'theme_primary', 'theme_secondary', 'theme_accent',
             'theme_use_gradient', 'theme_app_bg', 'theme_surface_bg', 'theme_text_color', 'theme_highlight_bg',
         ];
         $bools = [
             'dark_mode', 'notifications_enabled',
             'use_overtime_compensation', 'use_minimum_end_time',
-            'theme_use_gradient',
+            'theme_use_gradient', 'use_custom_schedule',
         ];
 
         $setClauses = [];
@@ -109,6 +122,9 @@ switch ($action) {
             if (!in_array($col, $allowed, true)) continue;
             if (in_array($col, $bools, true)) {
                 $val = $val ? 1 : 0;
+            } elseif ($col === 'work_hours_by_day') {
+                // Tableau → JSON (ou NULL si non fourni)
+                $val = is_array($val) ? json_encode(array_map('floatval', $val)) : null;
             }
             $setClauses[] = "`$col` = ?";
             $setParams[]  = $val;

--- a/db/migrations/migration_1.7.sql
+++ b/db/migrations/migration_1.7.sql
@@ -1,0 +1,16 @@
+-- ============================================================================
+-- Migration 1.7 — A appliquer une seule fois sur la base de prod existante.
+--
+-- Resume des changements de la 1.7 :
+--   * Horaires de travail variables par jour de la semaine (temps partiel).
+--     Ajoute un interrupteur `use_custom_schedule` et un tableau JSON de 7
+--     valeurs `work_hours_by_day` (Lun→Dim). Quand l'interrupteur est a 0,
+--     on retombe sur `required_work_hours` → aucun changement pour l'existant.
+--
+-- Usage :
+--   mysql -u <user> -p <database> < db/migrations/migration_1.7.sql
+-- ============================================================================
+
+ALTER TABLE `user_preferences`
+  ADD COLUMN `use_custom_schedule` BOOLEAN DEFAULT FALSE AFTER `required_work_hours`,
+  ADD COLUMN `work_hours_by_day` TEXT DEFAULT NULL AFTER `use_custom_schedule`;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -18,6 +18,8 @@ CREATE TABLE IF NOT EXISTS `user_preferences` (
   `dark_mode` BOOLEAN DEFAULT FALSE,
   `notifications_enabled` BOOLEAN DEFAULT FALSE,
   `required_work_hours` DECIMAL(5,2) DEFAULT 8.00,
+  `use_custom_schedule` BOOLEAN DEFAULT FALSE,
+  `work_hours_by_day` TEXT DEFAULT NULL,
   `required_lunch_break_minutes` INT DEFAULT 30,
   `end_of_day_threshold` DECIMAL(4,2) DEFAULT 0.80,
   `weekly_overtime_minutes` INT DEFAULT 0,

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -3,7 +3,18 @@ import { useAuth } from '../contexts/AuthContext';
 import { supabase, UserPreferences } from '../lib/supabase';
 import { exportUserData, downloadJSON, downloadCSV, importUserData, parseImportFile } from '../lib/dataTransfer';
 import { X, Moon, Sun, User, Lock, Clock, Coffee, Bell, Trash2, ArrowRightFromLine, Download, Upload, FileJson, FileText, CheckCircle, AlertCircle, Loader2, Palette, RotateCcw } from 'lucide-react';
-import { useTheme, ThemeMode, DEFAULT_THEME, CUSTOM_DEFAULTS, THEME_PRESETS, resolveHighlightBg } from '../contexts/ThemeContext';
+import { useTheme, ThemeMode, THEME_PRESETS, resolveHighlightBg } from '../contexts/ThemeContext';
+import { WEEKDAY_LABELS } from '../lib/workHours';
+
+// Construit le tableau de 7 champs (Lun→Dim) à partir des préférences.
+// Sans horaire personnalisé enregistré : valeur uniforme en semaine, 0 le week-end.
+function initScheduleStrings(prefs: UserPreferences | null): string[] {
+  if (prefs?.work_hours_by_day && prefs.work_hours_by_day.length === 7) {
+    return prefs.work_hours_by_day.map((h) => h.toString());
+  }
+  const uniform = (prefs?.required_work_hours ?? 8).toString();
+  return [uniform, uniform, uniform, uniform, uniform, '0', '0'];
+}
 
 interface SettingsProps {
   onClose: () => void;
@@ -12,12 +23,13 @@ interface SettingsProps {
 
 export function Settings({ onClose, initialPreferences }: SettingsProps) {
   const { user, logout } = useAuth();
-  const theme = useTheme();
   const [preferences, setPreferences] = useState<UserPreferences | null>(initialPreferences);
   const [newUsername, setNewUsername] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [workHours, setWorkHours] = useState(initialPreferences?.required_work_hours.toString() || '8');
+  const [useCustomSchedule, setUseCustomSchedule] = useState(initialPreferences?.use_custom_schedule || false);
+  const [workHoursByDay, setWorkHoursByDay] = useState<string[]>(initScheduleStrings(initialPreferences));
   const [lunchBreak, setLunchBreak] = useState(initialPreferences?.required_lunch_break_minutes.toString() || '30');
   const [endOfDayThreshold, setEndOfDayThreshold] = useState(initialPreferences?.end_of_day_threshold ? (initialPreferences.end_of_day_threshold * 100).toString() : '80');
   const [minimumEndTime, setMinimumEndTime] = useState(initialPreferences?.minimum_end_time || '');
@@ -56,6 +68,8 @@ export function Settings({ onClose, initialPreferences }: SettingsProps) {
       setPreferences(data);
       setNotificationsEnabled(data.notifications_enabled || false);
       setWorkHours(data.required_work_hours.toString());
+      setUseCustomSchedule(data.use_custom_schedule || false);
+      setWorkHoursByDay(initScheduleStrings(data));
       setLunchBreak(data.required_lunch_break_minutes.toString());
       setEndOfDayThreshold(data.end_of_day_threshold ? (data.end_of_day_threshold * 100).toString() : '80');
       setMinimumEndTime(data.minimum_end_time || '');
@@ -145,10 +159,21 @@ export function Settings({ onClose, initialPreferences }: SettingsProps) {
       return;
     }
 
+    const scheduleHours = workHoursByDay.map((h) => parseFloat(h));
+    if (useCustomSchedule && scheduleHours.some((h) => isNaN(h) || h < 0 || h > 24)) {
+      setError('Chaque horaire journalier doit être un nombre valide (0-24)');
+      return;
+    }
+    // On enregistre toujours le tableau (NaN → 0) pour conserver les valeurs
+    // même lorsque l'horaire personnalisé est désactivé.
+    const safeSchedule = scheduleHours.map((h) => (isNaN(h) ? 0 : h));
+
     const { error: updateError } = await supabase
       .from('user_preferences')
       .update({
         required_work_hours: hours,
+        use_custom_schedule: useCustomSchedule,
+        work_hours_by_day: safeSchedule,
         required_lunch_break_minutes: minutes,
         end_of_day_threshold: threshold,
         minimum_end_time: minimumEndTime.trim() || null,
@@ -391,18 +416,79 @@ export function Settings({ onClose, initialPreferences }: SettingsProps) {
               <h3 className="text-lg font-semibold">Préférences de travail</h3>
             </div>
             <div className="space-y-3">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-100 mb-2">
-                  Heures de travail requises par jour
-                </label>
-                <input
-                  type="number"
-                  step="0.5"
-                  value={workHours}
-                  onChange={(e) => setWorkHours(e.target.value)}
-                  className="w-full px-4 py-3 rounded-xl border-2 border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 focus:border-purple-500 dark:focus:border-purple-400 focus:ring-4 focus:ring-purple-500/20 transition-all outline-none text-base"
-                />
+              {!useCustomSchedule && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-100 mb-2">
+                    Heures de travail requises par jour
+                  </label>
+                  <input
+                    type="number"
+                    step="0.5"
+                    value={workHours}
+                    onChange={(e) => setWorkHours(e.target.value)}
+                    className="w-full px-4 py-3 rounded-xl border-2 border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 focus:border-purple-500 dark:focus:border-purple-400 focus:ring-4 focus:ring-purple-500/20 transition-all outline-none text-base"
+                  />
+                </div>
+              )}
+
+              <div className="flex items-center justify-between p-4 bg-gradient-to-r from-gray-50 to-gray-100 dark:from-slate-800 dark:to-slate-700 rounded-2xl">
+                <div className="flex items-center gap-3">
+                  <Clock className={`w-6 h-6 ${useCustomSchedule ? 'text-blue-600 dark:text-blue-300' : 'text-gray-400'}`} />
+                  <div>
+                    <div className="font-medium text-gray-800 dark:text-gray-100">
+                      Horaire personnalisé par jour
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                      Pour les temps partiels : heures différentes selon le jour
+                    </div>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setUseCustomSchedule(!useCustomSchedule)}
+                  className={`relative w-16 h-8 rounded-full transition-all shrink-0 ${
+                    useCustomSchedule
+                      ? 'bg-gradient-to-r from-blue-500 to-cyan-600'
+                      : 'bg-gray-300'
+                  }`}
+                >
+                  <div
+                    className={`absolute top-1 left-1 w-6 h-6 bg-white rounded-full shadow-lg transition-transform ${
+                      useCustomSchedule ? 'transform translate-x-8' : ''
+                    }`}
+                  />
+                </button>
               </div>
+
+              {useCustomSchedule && (
+                <div className="space-y-3">
+                  <div className="grid grid-cols-4 sm:grid-cols-7 gap-1.5">
+                    {WEEKDAY_LABELS.map((label, i) => (
+                      <div key={label} className="flex flex-col items-start">
+                        <label className="text-xs font-medium text-gray-600 dark:text-gray-300 mb-1">
+                          {label}
+                        </label>
+                        <input
+                          type="number"
+                          step="0.5"
+                          min="0"
+                          max="24"
+                          value={workHoursByDay[i]}
+                          onChange={(e) => {
+                            const next = [...workHoursByDay];
+                            next[i] = e.target.value;
+                            setWorkHoursByDay(next);
+                          }}
+                          className="w-full px-2 py-2 rounded-xl border-2 border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 focus:border-purple-500 dark:focus:border-purple-400 focus:ring-2 focus:ring-purple-500/20 transition-all outline-none text-sm text-left"
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Heures par jour (Lun→Dim). Mettez 0 pour un jour non travaillé. L'objectif, l'heure de fin, les heures supplémentaires et les statistiques s'adaptent au jour de la semaine.
+                  </p>
+                </div>
+              )}
               <div>
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-100 mb-2">
                   <div className="flex items-center gap-2">

--- a/src/components/Statistics.tsx
+++ b/src/components/Statistics.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
-import { WorkSession } from '../lib/supabase';
+import { WorkSession, UserPreferences } from '../lib/supabase';
 import { BarChart3, Clock, Coffee, LogIn, LogOut as LogOutIcon, TrendingUp, Calendar } from 'lucide-react';
+import { getRequiredHoursForDate } from '../lib/workHours';
 
 interface StatisticsProps {
   sessions: WorkSession[];
-  requiredWorkHours: number;
+  preferences: UserPreferences;
 }
 
 type Period = 'week' | '7days' | '14days' | '30days';
@@ -29,7 +30,7 @@ interface Stats {
   }>;
 }
 
-export function Statistics({ sessions, requiredWorkHours }: StatisticsProps) {
+export function Statistics({ sessions, preferences }: StatisticsProps) {
   const [period, setPeriod] = useState<Period>('week');
   const [stats, setStats] = useState<Stats | null>(null);
 
@@ -204,7 +205,11 @@ export function Statistics({ sessions, requiredWorkHours }: StatisticsProps) {
     );
   }
 
-  const expectedDailyMinutes = requiredWorkHours * 60;
+  // Objectif (en minutes) attendu pour une date donnée, selon l'horaire du jour.
+  const expectedMinutesForDate = (date: string) => {
+    const [y, m, d] = date.split('-').map(Number);
+    return getRequiredHoursForDate(preferences, new Date(y, m - 1, d)) * 60;
+  };
 
   const minDuration = Math.min(...stats.dailyStats.map(s => s.workDuration));
   const avgDuration = stats.avgWorkDuration;
@@ -285,7 +290,7 @@ export function Statistics({ sessions, requiredWorkHours }: StatisticsProps) {
               const normalizedValue = Math.max(0, Math.min(100,
                 ((day.workDuration - rangeMin) / (rangeMax - rangeMin)) * 100
               ));
-              const isAboveTarget = day.workDuration >= expectedDailyMinutes;
+              const isAboveTarget = day.workDuration >= expectedMinutesForDate(day.date);
 
               return (
                 <div key={index} className="space-y-1">

--- a/src/components/TimeTracker.tsx
+++ b/src/components/TimeTracker.tsx
@@ -8,6 +8,7 @@ import { EditHistory } from './EditHistory';
 import { ConfirmModal } from './ConfirmModal';
 import { ChangelogModal } from './ChangelogModal';
 import { APP_VERSION, majorMinor } from '../lib/changelog';
+import { getRequiredHoursForDate } from '../lib/workHours';
 
 export function TimeTracker() {
   const { user, logout } = useAuth();
@@ -306,8 +307,13 @@ export function TimeTracker() {
       }
     });
 
-    const daysWorked = new Set(data.map(s => s.date)).size;
-    const expectedMinutes = daysWorked * preferences.required_work_hours * 60;
+    const workedDates = new Set(data.map(s => s.date));
+    let expectedMinutes = 0;
+    workedDates.forEach((date) => {
+      // `date` est une chaîne 'YYYY-MM-DD' : on la parse en local pour obtenir le bon jour de semaine.
+      const [y, m, d] = date.split('-').map(Number);
+      expectedMinutes += getRequiredHoursForDate(preferences, new Date(y, m - 1, d)) * 60;
+    });
     const overtimeMinutes = Math.max(0, Math.round(totalMinutes - expectedMinutes));
 
     setOvertimeInput(formatOvertimeMinutes(overtimeMinutes));
@@ -492,7 +498,7 @@ export function TimeTracker() {
 
     const availableMinutes = (minEndTime.getTime() - firstClockIn.getTime()) / (1000 * 60);
 
-    const requiredMinutes = preferences.required_work_hours * 60;
+    const requiredMinutes = getRequiredHoursForDate(preferences, currentTime) * 60;
     const adaptedBreak = availableMinutes - requiredMinutes;
     return Math.max(adaptedBreak, defaultBreak);
   };
@@ -502,7 +508,7 @@ export function TimeTracker() {
 
     const { totalMinutes, lunchBreakMinutes } = calculateWorkTime();
     const plannedMinutes = getPlannedFutureMinutes();
-    let requiredMinutes = preferences.required_work_hours * 60;
+    let requiredMinutes = getRequiredHoursForDate(preferences, currentTime) * 60;
 
     if (preferences.use_overtime_compensation && preferences.weekly_overtime_minutes > 0) {
       requiredMinutes -= preferences.weekly_overtime_minutes;
@@ -536,7 +542,7 @@ export function TimeTracker() {
     if (!preferences || !activeSession) return null;
 
     const { totalMinutes } = calculateWorkTime();
-    const requiredMinutes = preferences.required_work_hours * 60;
+    const requiredMinutes = getRequiredHoursForDate(preferences, currentTime) * 60;
 
     if (totalMinutes <= requiredMinutes) return null;
 
@@ -548,7 +554,7 @@ export function TimeTracker() {
 
     const { totalMinutes } = calculateWorkTime();
     const plannedMinutes = getPlannedFutureMinutes();
-    const requiredMinutes = preferences ? preferences.required_work_hours * 60 : 480;
+    const requiredMinutes = preferences ? getRequiredHoursForDate(preferences, currentTime) * 60 : 480;
     const threshold = preferences?.end_of_day_threshold || 0.8;
 
     if (totalMinutes + plannedMinutes >= requiredMinutes * threshold) {
@@ -592,7 +598,7 @@ export function TimeTracker() {
   const { totalMinutes, lunchBreakMinutes } = calculateWorkTime();
   const endTime = calculateEndTime();
   const workProgress = preferences
-    ? (totalMinutes / (preferences.required_work_hours * 60)) * 100
+    ? (totalMinutes / (getRequiredHoursForDate(preferences, currentTime) * 60)) * 100
     : 0;
   const lunchBreakTime = getLunchBreakTime();
   const overtimeMinutes = getOvertimeMinutes();
@@ -718,7 +724,7 @@ export function TimeTracker() {
                     Temps travaillé aujourd'hui
                   </span>
                   <span className="text-sm text-gray-600 dark:text-gray-300 mt-1">
-                    Objectif: {formatDuration((preferences?.required_work_hours || 8) * 60)}
+                    Objectif: {formatDuration((preferences ? getRequiredHoursForDate(preferences, currentTime) : 8) * 60)}
                   </span>
                 </div>
                 <span className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 dark:from-blue-300 dark:to-purple-300 bg-clip-text text-transparent text-center md:text-right">
@@ -976,7 +982,7 @@ export function TimeTracker() {
           <div className="mt-8">
             <Statistics
               sessions={allSessions}
-              requiredWorkHours={preferences.required_work_hours}
+              preferences={preferences}
             />
           </div>
         )}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.6.2';
+export const APP_VERSION = '1.7.0';
 
 /** Extrait la version majeure.mineure (ex: '1.6.1' → '1.6') */
 export function majorMinor(version: string): string {
@@ -14,6 +14,16 @@ export interface ChangelogEntry {
 }
 
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    version: '1.7',
+    date: '1 juin 2026',
+    title: 'Horaires variables par jour',
+    items: [
+      { emoji: '🗓️', text: "Nouvelle option dans les paramètres : activez l'« Horaire personnalisé par jour » pour définir un nombre d'heures différent selon le jour de la semaine (Lun→Dim). Idéal pour les temps partiels." },
+      { emoji: '0️⃣', text: "Mettez 0 sur un jour pour indiquer un jour non travaillé. Sans activation, le comportement reste identique avec une seule valeur d'heures par jour." },
+      { emoji: '🧮', text: "Tous les calculs s'adaptent à l'horaire du jour : objectif quotidien, heure de fin estimée, progression, pause déjeuner adaptative, heures supplémentaires sur la période et statistiques." },
+    ],
+  },
   {
     version: '1.6',
     date: '8 avril 2026',

--- a/src/lib/dataTransfer.ts
+++ b/src/lib/dataTransfer.ts
@@ -112,6 +112,10 @@ export async function importUserData(userId: string, data: ExportData): Promise<
     if (prefs.theme_text_color !== undefined) updateData.theme_text_color = prefs.theme_text_color;
     if (prefs.theme_highlight_bg !== undefined) updateData.theme_highlight_bg = prefs.theme_highlight_bg;
 
+    // Champs ajoutés en 1.7 (horaires par jour)
+    if (prefs.use_custom_schedule !== undefined) updateData.use_custom_schedule = prefs.use_custom_schedule;
+    if (prefs.work_hours_by_day !== undefined) updateData.work_hours_by_day = prefs.work_hours_by_day;
+
     const { error } = await supabase
       .from('user_preferences')
       .update(updateData)

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -16,6 +16,8 @@ export interface UserPreferences {
   dark_mode: boolean;
   notifications_enabled: boolean;
   required_work_hours: number;
+  use_custom_schedule: boolean;
+  work_hours_by_day: number[] | null;
   required_lunch_break_minutes: number;
   end_of_day_threshold: number;
   weekly_overtime_minutes: number;

--- a/src/lib/workHours.ts
+++ b/src/lib/workHours.ts
@@ -1,0 +1,28 @@
+/**
+ * Horaires de travail variables par jour de la semaine (1.7).
+ *
+ * Quand `use_custom_schedule` est actif, l'objectif quotidien dépend du jour
+ * de la semaine (`work_hours_by_day`, tableau de 7 valeurs Lun→Dim). Sinon on
+ * retombe sur la valeur unique `required_work_hours`.
+ */
+import type { UserPreferences } from './supabase';
+
+// Libellés des jours, dans l'ordre du tableau work_hours_by_day (Lun → Dim).
+export const WEEKDAY_LABELS = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim'];
+
+/** Convertit getDay() (0=Dim..6=Sam) vers notre index (Lun=0..Dim=6). */
+export function weekdayIndex(date: Date): number {
+  return (date.getDay() + 6) % 7;
+}
+
+/** Horaire requis (en heures) pour la date donnée, selon les préférences. */
+export function getRequiredHoursForDate(
+  prefs: Pick<UserPreferences, 'required_work_hours' | 'use_custom_schedule' | 'work_hours_by_day'>,
+  date: Date
+): number {
+  if (prefs.use_custom_schedule && prefs.work_hours_by_day) {
+    const v = prefs.work_hours_by_day[weekdayIndex(date)];
+    if (typeof v === 'number' && !Number.isNaN(v)) return v;
+  }
+  return prefs.required_work_hours;
+}


### PR DESCRIPTION
## Contexte
L'objectif quotidien était une valeur unique (\`required_work_hours\`), inadaptée aux temps partiels dont le nombre d'heures varie selon le jour.

## Fonctionnalité
Nouveau toggle **« Horaire personnalisé par jour »** dans les paramètres : 7 valeurs Lun→Dim (\`0\` = jour non travaillé). Tous les calculs s'adaptent à l'horaire du jour de la semaine :
- objectif quotidien, heure de fin estimée, progression
- pause déjeuner adaptative
- heures supplémentaires sur la période (somme par date réellement pointée)
- statistiques (cible par jour)

Comportement **inchangé par défaut** : toggle désactivé → valeur uniforme comme avant.

## Changements techniques
- **DB** : colonnes \`use_custom_schedule\` (BOOL) + \`work_hours_by_day\` (TEXT/JSON) + \`db/migrations/migration_1.7.sql\`
- **API** : \`helpers.php\` (cast + json_decode), \`preferences.php\` (whitelist, validation 7 nombres, json_encode)
- **Front** : util partagé \`src/lib/workHours.ts\`, adaptation TimeTracker/Statistics/Settings, types, import/export
- **Version** : 1.7.0 (changelog popup + README)

## ⚠️ Déploiement
Appliquer la migration **avant** le code en prod (phpMyAdmin) :
\`\`\`sql
ALTER TABLE \`user_preferences\`
  ADD COLUMN \`use_custom_schedule\` BOOLEAN DEFAULT FALSE AFTER \`required_work_hours\`,
  ADD COLUMN \`work_hours_by_day\` TEXT DEFAULT NULL AFTER \`use_custom_schedule\`;
\`\`\`

## Vérifications
- \`npm run typecheck\` / \`npm run lint\` : aucune nouvelle erreur (les erreurs restantes préexistent sur main)
- Testé en local via Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)