### PR TITLE
v1.7.1 — Journées sans pause de midi (horaire personnalisé)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Application de suivi du temps de travail en self-hosted, construite avec React +
 - **Thèmes** : sélecteur Clair / Sombre / Custom, 12 presets (OLED, Cosy, Dracula, Nord, Solarized…) et personnalisation complète des couleurs (primaire, secondaire, accent, fond de page, fond des cartes, mises en avant, police auto/claire/foncée), persistés en base par utilisateur
 - Configuration : heures de travail requises, durée de pause déjeuner, seuil de départ (%)
 - **Horaires variables par jour** : option « Horaire personnalisé par jour » pour les temps partiels — un nombre d'heures différent pour chaque jour (Lun→Dim, `0` = jour non travaillé). Tous les calculs s'adaptent au jour de la semaine
+- **Journées sans pause de midi** : dans l'horaire personnalisé, une case sous chaque jour déclare une journée continue — l'heure de sortie est alors calculée sans pause déjeuner (ex. demi-journée de 4,5 h finissant à midi)
 - Gestion des heures supplémentaires (compensation, période de calcul configurable)
 - Export des données (JSON / CSV) et import
 - Suppression complète du compte (cascade sur toutes les données)
@@ -215,6 +216,12 @@ display_errors = Off
 ---
 
 ## Changelog
+
+### v1.7.1 — 4 juin 2026
+- **Journées sans pause de midi** : dans l'horaire personnalisé par jour, une case à cocher sous chaque jour permet de déclarer une journée continue (sans pause déjeuner) — l'heure de sortie estimée n'ajoute plus de pause, idéal pour les demi-journées de temps partiel (ex. 4,5 h finissant à midi)
+- Sur un jour coché, l'écran « Pause déjeuner en cours / Dépassement de pause » ne se déclenche plus
+- Comportement inchangé par défaut : sans case cochée, la pause déjeuner s'applique comme avant
+- Base de données : nouvelle colonne `no_lunch_break_by_day` (migration `db/migrations/migration_1.7.1.sql`)
 
 ### v1.7.0 — 1 juin 2026
 - **Horaires variables par jour de la semaine** : nouvelle option « Horaire personnalisé par jour » dans les paramètres, pensée pour les temps partiels — définissez un nombre d'heures différent pour chaque jour (Lun→Dim), `0` pour un jour non travaillé

--- a/api/helpers.php
+++ b/api/helpers.php
@@ -161,6 +161,13 @@ function cast_prefs(array $row): array
     } else {
         $row['work_hours_by_day'] = null;
     }
+    // Pause de midi par jour (1.7.1) : stocke en JSON, expose un tableau de booleens (ou null).
+    if (isset($row['no_lunch_break_by_day']) && $row['no_lunch_break_by_day'] !== null) {
+        $decoded = json_decode($row['no_lunch_break_by_day'], true);
+        $row['no_lunch_break_by_day'] = is_array($decoded) ? array_map('boolval', $decoded) : null;
+    } else {
+        $row['no_lunch_break_by_day'] = null;
+    }
     $row['theme_mode']       = $row['theme_mode']       ?? 'light';
     $row['theme_primary']    = $row['theme_primary']    ?? '#3b82f6';
     $row['theme_secondary']  = $row['theme_secondary']  ?? '#9333ea';

--- a/api/preferences.php
+++ b/api/preferences.php
@@ -100,12 +100,20 @@ switch ($action) {
             }
         }
 
+        // Pause de midi par jour (1.7.1) : tableau de 7 booleens, ou null.
+        if (isset($data['no_lunch_break_by_day']) && $data['no_lunch_break_by_day'] !== null) {
+            $noLunch = $data['no_lunch_break_by_day'];
+            if (!is_array($noLunch) || count($noLunch) !== 7) {
+                json_error('no_lunch_break_by_day doit comporter 7 valeurs', 400);
+            }
+        }
+
         $allowed = [
             'dark_mode', 'notifications_enabled', 'required_work_hours',
             'required_lunch_break_minutes', 'end_of_day_threshold',
             'weekly_overtime_minutes', 'use_overtime_compensation',
             'minimum_end_time', 'use_minimum_end_time', 'last_seen_version',
-            'overtime_period', 'use_custom_schedule', 'work_hours_by_day',
+            'overtime_period', 'use_custom_schedule', 'work_hours_by_day', 'no_lunch_break_by_day',
             'theme_mode', 'theme_primary', 'theme_secondary', 'theme_accent',
             'theme_use_gradient', 'theme_app_bg', 'theme_surface_bg', 'theme_text_color', 'theme_highlight_bg',
         ];
@@ -125,6 +133,9 @@ switch ($action) {
             } elseif ($col === 'work_hours_by_day') {
                 // Tableau → JSON (ou NULL si non fourni)
                 $val = is_array($val) ? json_encode(array_map('floatval', $val)) : null;
+            } elseif ($col === 'no_lunch_break_by_day') {
+                // Tableau de booleens → JSON (ou NULL si non fourni)
+                $val = is_array($val) ? json_encode(array_map('boolval', $val)) : null;
             }
             $setClauses[] = "`$col` = ?";
             $setParams[]  = $val;

--- a/db/migrations/migration_1.7.1.sql
+++ b/db/migrations/migration_1.7.1.sql
@@ -1,0 +1,15 @@
+-- ============================================================================
+-- Migration 1.7.1 — A appliquer une seule fois sur la base de prod existante.
+--
+-- Resume des changements de la 1.7.1 :
+--   * Pause de midi optionnelle par jour (temps partiel). Ajoute un tableau
+--     JSON de 7 booleens `no_lunch_break_by_day` (Lun→Dim). Quand la case
+--     d'un jour est cochee, aucune pause dejeuner n'est comptee ce jour-la
+--     dans le calcul de l'heure de sortie. NULL → comportement inchange.
+--
+-- Usage :
+--   mysql -u <user> -p <database> < db/migrations/migration_1.7.1.sql
+-- ============================================================================
+
+ALTER TABLE `user_preferences`
+  ADD COLUMN `no_lunch_break_by_day` TEXT DEFAULT NULL AFTER `work_hours_by_day`;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS `user_preferences` (
   `required_work_hours` DECIMAL(5,2) DEFAULT 8.00,
   `use_custom_schedule` BOOLEAN DEFAULT FALSE,
   `work_hours_by_day` TEXT DEFAULT NULL,
+  `no_lunch_break_by_day` TEXT DEFAULT NULL,
   `required_lunch_break_minutes` INT DEFAULT 30,
   `end_of_day_threshold` DECIMAL(4,2) DEFAULT 0.80,
   `weekly_overtime_minutes` INT DEFAULT 0,

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -16,6 +16,14 @@ function initScheduleStrings(prefs: UserPreferences | null): string[] {
   return [uniform, uniform, uniform, uniform, uniform, '0', '0'];
 }
 
+// Tableau de 7 cases « pas de pause de midi » (Lun→Dim). Par défaut : pause partout.
+function initNoLunchFlags(prefs: UserPreferences | null): boolean[] {
+  if (prefs?.no_lunch_break_by_day && prefs.no_lunch_break_by_day.length === 7) {
+    return prefs.no_lunch_break_by_day.map(Boolean);
+  }
+  return [false, false, false, false, false, false, false];
+}
+
 interface SettingsProps {
   onClose: () => void;
   initialPreferences: UserPreferences | null;
@@ -30,6 +38,7 @@ export function Settings({ onClose, initialPreferences }: SettingsProps) {
   const [workHours, setWorkHours] = useState(initialPreferences?.required_work_hours.toString() || '8');
   const [useCustomSchedule, setUseCustomSchedule] = useState(initialPreferences?.use_custom_schedule || false);
   const [workHoursByDay, setWorkHoursByDay] = useState<string[]>(initScheduleStrings(initialPreferences));
+  const [noLunchByDay, setNoLunchByDay] = useState<boolean[]>(initNoLunchFlags(initialPreferences));
   const [lunchBreak, setLunchBreak] = useState(initialPreferences?.required_lunch_break_minutes.toString() || '30');
   const [endOfDayThreshold, setEndOfDayThreshold] = useState(initialPreferences?.end_of_day_threshold ? (initialPreferences.end_of_day_threshold * 100).toString() : '80');
   const [minimumEndTime, setMinimumEndTime] = useState(initialPreferences?.minimum_end_time || '');
@@ -70,6 +79,7 @@ export function Settings({ onClose, initialPreferences }: SettingsProps) {
       setWorkHours(data.required_work_hours.toString());
       setUseCustomSchedule(data.use_custom_schedule || false);
       setWorkHoursByDay(initScheduleStrings(data));
+      setNoLunchByDay(initNoLunchFlags(data));
       setLunchBreak(data.required_lunch_break_minutes.toString());
       setEndOfDayThreshold(data.end_of_day_threshold ? (data.end_of_day_threshold * 100).toString() : '80');
       setMinimumEndTime(data.minimum_end_time || '');
@@ -174,6 +184,7 @@ export function Settings({ onClose, initialPreferences }: SettingsProps) {
         required_work_hours: hours,
         use_custom_schedule: useCustomSchedule,
         work_hours_by_day: safeSchedule,
+        no_lunch_break_by_day: noLunchByDay,
         required_lunch_break_minutes: minutes,
         end_of_day_threshold: threshold,
         minimum_end_time: minimumEndTime.trim() || null,
@@ -481,11 +492,30 @@ export function Settings({ onClose, initialPreferences }: SettingsProps) {
                           }}
                           className="w-full px-2 py-2 rounded-xl border-2 border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 focus:border-purple-500 dark:focus:border-purple-400 focus:ring-2 focus:ring-purple-500/20 transition-all outline-none text-sm text-left"
                         />
+                        <label
+                          className="flex items-center gap-1 mt-1.5 cursor-pointer select-none"
+                          title="Journée continue : aucune pause de midi n'est comptée ce jour-là"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={noLunchByDay[i]}
+                            onChange={(e) => {
+                              const next = [...noLunchByDay];
+                              next[i] = e.target.checked;
+                              setNoLunchByDay(next);
+                            }}
+                            className="w-3.5 h-3.5 rounded border-gray-300 dark:border-slate-600 accent-purple-600 cursor-pointer"
+                          />
+                          <Coffee className={`w-3.5 h-3.5 ${noLunchByDay[i] ? 'text-gray-300 dark:text-gray-600' : 'text-orange-500 dark:text-orange-400'}`} />
+                        </label>
                       </div>
                     ))}
                   </div>
                   <p className="text-xs text-gray-500 dark:text-gray-400">
                     Heures par jour (Lun→Dim). Mettez 0 pour un jour non travaillé. L'objectif, l'heure de fin, les heures supplémentaires et les statistiques s'adaptent au jour de la semaine.
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Cochez la case sous un jour pour une <span className="font-medium">journée sans pause de midi</span> (journée continue) : l'heure de sortie est alors calculée sans pause déjeuner.
                   </p>
                 </div>
               )}

--- a/src/components/TimeTracker.tsx
+++ b/src/components/TimeTracker.tsx
@@ -8,7 +8,7 @@ import { EditHistory } from './EditHistory';
 import { ConfirmModal } from './ConfirmModal';
 import { ChangelogModal } from './ChangelogModal';
 import { APP_VERSION, majorMinor } from '../lib/changelog';
-import { getRequiredHoursForDate } from '../lib/workHours';
+import { getRequiredHoursForDate, hasLunchBreakForDate } from '../lib/workHours';
 
 export function TimeTracker() {
   const { user, logout } = useAuth();
@@ -483,6 +483,9 @@ export function TimeTracker() {
   const getEffectiveLunchBreakMinutes = () => {
     if (!preferences) return 30;
 
+    // Jour sans pause de midi (1.7.1) : aucune pause n'est attendue ni comptée.
+    if (!hasLunchBreakForDate(preferences, currentTime)) return 0;
+
     const defaultBreak = preferences.required_lunch_break_minutes;
 
     const pastSessions = todaySessions.filter(
@@ -551,6 +554,9 @@ export function TimeTracker() {
 
   const isOnLunchBreak = () => {
     if (todaySessions.length === 0 || activeSession) return false;
+
+    // Jour sans pause de midi (1.7.1) : pas d'écran « Pause déjeuner en cours ».
+    if (preferences && !hasLunchBreakForDate(preferences, currentTime)) return false;
 
     const { totalMinutes } = calculateWorkTime();
     const plannedMinutes = getPlannedFutureMinutes();

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '1.7.0';
+export const APP_VERSION = '1.7.1';
 
 /** Extrait la version majeure.mineure (ex: '1.6.1' → '1.6') */
 export function majorMinor(version: string): string {
@@ -19,8 +19,8 @@ export const CHANGELOG: ChangelogEntry[] = [
     date: '1 juin 2026',
     title: 'Horaires variables par jour',
     items: [
-      { emoji: '🗓️', text: "Nouvelle option dans les paramètres : activez l'« Horaire personnalisé par jour » pour définir un nombre d'heures différent selon le jour de la semaine (Lun→Dim). Idéal pour les temps partiels." },
-      { emoji: '0️⃣', text: "Mettez 0 sur un jour pour indiquer un jour non travaillé. Sans activation, le comportement reste identique avec une seule valeur d'heures par jour." },
+      { emoji: '🗓️', text: "Nouvelle option dans les paramètres : activez l'« Horaire personnalisé par jour » pour définir un nombre d'heures différent selon le jour de la semaine (Lun→Dim). Idéal pour les temps partiels. Mettez 0 pour un jour non travaillé." },
+      { emoji: '☕', text: "Une case sous chaque jour permet de déclarer une journée continue, sans pause de midi : l'heure de sortie est alors calculée sans pause déjeuner (ex. demi-journée à 4,5 h qui se termine à midi)." },
       { emoji: '🧮', text: "Tous les calculs s'adaptent à l'horaire du jour : objectif quotidien, heure de fin estimée, progression, pause déjeuner adaptative, heures supplémentaires sur la période et statistiques." },
     ],
   },

--- a/src/lib/dataTransfer.ts
+++ b/src/lib/dataTransfer.ts
@@ -116,6 +116,9 @@ export async function importUserData(userId: string, data: ExportData): Promise<
     if (prefs.use_custom_schedule !== undefined) updateData.use_custom_schedule = prefs.use_custom_schedule;
     if (prefs.work_hours_by_day !== undefined) updateData.work_hours_by_day = prefs.work_hours_by_day;
 
+    // Champs ajoutés en 1.7.1 (pause de midi par jour)
+    if (prefs.no_lunch_break_by_day !== undefined) updateData.no_lunch_break_by_day = prefs.no_lunch_break_by_day;
+
     const { error } = await supabase
       .from('user_preferences')
       .update(updateData)

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -18,6 +18,7 @@ export interface UserPreferences {
   required_work_hours: number;
   use_custom_schedule: boolean;
   work_hours_by_day: number[] | null;
+  no_lunch_break_by_day: boolean[] | null;
   required_lunch_break_minutes: number;
   end_of_day_threshold: number;
   weekly_overtime_minutes: number;

--- a/src/lib/workHours.ts
+++ b/src/lib/workHours.ts
@@ -26,3 +26,19 @@ export function getRequiredHoursForDate(
   }
   return prefs.required_work_hours;
 }
+
+/**
+ * Y a-t-il une pause de midi pour la date donnée ? (1.7.1)
+ * Avec l'horaire personnalisé, chaque jour peut être marqué « sans pause »
+ * (journée continue, ex. demi-journée de temps partiel) : dans ce cas la
+ * pause déjeuner n'entre plus dans le calcul de l'heure de sortie.
+ */
+export function hasLunchBreakForDate(
+  prefs: Pick<UserPreferences, 'use_custom_schedule' | 'no_lunch_break_by_day'>,
+  date: Date
+): boolean {
+  if (prefs.use_custom_schedule && prefs.no_lunch_break_by_day) {
+    return !prefs.no_lunch_break_by_day[weekdayIndex(date)];
+  }
+  return true;
+}


### PR DESCRIPTION
## Résumé

Corrige le calcul de l'heure de sortie pour les temps partiels : sur une demi-journée (ex. 4,5 h finissant à midi), le site ajoutait systématiquement la pause déjeuner à l'heure de sortie estimée.

Dans le mode « Horaire personnalisé par jour », une **case à cocher sous chaque jour** (Lun→Dim) permet désormais de déclarer une **journée continue, sans pause de midi** :
- l'heure de sortie estimée est calculée sans ajouter de pause déjeuner ;
- l'écran « Pause déjeuner en cours / Dépassement de pause » ne se déclenche plus ce jour-là ;
- comportement inchangé par défaut (case décochée = pause comme avant).

## Changements

- **DB** : nouvelle colonne `no_lunch_break_by_day` (TEXT/JSON, 7 booléens Lun→Dim, `NULL` = inchangé) — `db/schema.sql` + `db/migrations/migration_1.7.1.sql`
- **API** (`preferences.php`, `helpers.php`) : validation (7 valeurs), colonne autorisée à l'update, encodage/décodage JSON
- **Frontend** :
  - `workHours.ts` : helper `hasLunchBreakForDate(prefs, date)`
  - `TimeTracker.tsx` : `getEffectiveLunchBreakMinutes()` → 0 sur un jour sans pause ; garde dans `isOnLunchBreak()`
  - `Settings.tsx` : case ☕ sous chaque jour de la grille + texte d'aide
  - `dataTransfer.ts` : champ inclus dans l'export/import JSON
  - `changelog.ts` : `APP_VERSION = 1.7.1`, entrée 1.7 mise à jour
- **README** : section fonctionnalités + changelog v1.7.1

## Déploiement prod (dans cet ordre)

1. `mysql -u <user> -p <database> < db/migrations/migration_1.7.1.sql`
2. Uploader `api/preferences.php` + `api/helpers.php`
3. `npm run build` puis uploader `dist/`

## Tests

- `npm run build` ✅
- `php -l` sur les deux fichiers API ✅
- Migration appliquée et vérifiée sur la base dev Docker ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)